### PR TITLE
feat: add suggested fixes

### DIFF
--- a/exptostd.go
+++ b/exptostd.go
@@ -164,8 +164,8 @@ func maybeReplaceImport(
 				{
 					TextEdits: []analysis.TextEdit{
 						{
-							Pos:     importSpec.Pos(),
-							End:     importSpec.End(),
+							Pos:     importSpec.Path.Pos(),
+							End:     importSpec.Path.End(),
 							NewText: []byte(replaceText),
 						},
 					},
@@ -175,11 +175,15 @@ func maybeReplaceImport(
 	}
 
 	if imp, ok := imports["golang.org/x/exp/maps"]; ok && !shouldKeepExpMaps {
-		pass.Report(diagnostic(imp, `"maps"`))
+		if imp.Name == nil || imp.Name.Name == "" {
+			pass.Report(diagnostic(imp, `"maps"`))
+		}
 	}
 
 	if imp, ok := imports["golang.org/x/exp/slices"]; ok && !shouldKeepExpSlices {
-		pass.Report(diagnostic(imp, `"slices"`))
+		if imp.Name == nil || imp.Name.Name == "" {
+			pass.Report(diagnostic(imp, `"slices"`))
+		}
 	}
 }
 

--- a/exptostd_test.go
+++ b/exptostd_test.go
@@ -17,6 +17,9 @@ func TestAnalyzer(t *testing.T) {
 	}{
 		{dir: "expmaps"},
 		{dir: "expslices"},
+		{dir: "expboth"},
+		{dir: "expnone"},
+		{dir: "expmixed"},
 	}
 
 	for _, test := range testCases {
@@ -60,5 +63,5 @@ func run(t *testing.T, a *analysis.Analyzer, dir string, patterns ...string) []*
 		t.Fatal(err)
 	}
 
-	return analysistest.Run(t, srcPath, a, patterns...)
+	return analysistest.RunWithSuggestedFixes(t, srcPath, a, patterns...)
 }

--- a/exptostd_test.go
+++ b/exptostd_test.go
@@ -25,12 +25,12 @@ func TestAnalyzer(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.dir, func(t *testing.T) {
-			run(t, exptostd.NewAnalyzer(), test.dir)
+			runWithSuggestedFixes(t, exptostd.NewAnalyzer(), test.dir)
 		})
 	}
 }
 
-func run(t *testing.T, a *analysis.Analyzer, dir string, patterns ...string) []*analysistest.Result {
+func runWithSuggestedFixes(t *testing.T, a *analysis.Analyzer, dir string, patterns ...string) []*analysistest.Result {
 	t.Helper()
 
 	wd, err := os.Getwd()

--- a/exptostd_test.go
+++ b/exptostd_test.go
@@ -20,6 +20,7 @@ func TestAnalyzer(t *testing.T) {
 		{dir: "expboth"},
 		{dir: "expnone"},
 		{dir: "expmixed"},
+		{dir: "expalias"},
 	}
 
 	for _, test := range testCases {

--- a/testdata/src/expalias/alias.go
+++ b/testdata/src/expalias/alias.go
@@ -1,11 +1,13 @@
 package expalias
 
 import (
+	"golang.org/x/exp/maps"
 	aliased "golang.org/x/exp/maps"
-	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"golang.org/x/exp/slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(m map[string]string, a, b []string) {
 	aliased.Clone(m)
+	maps.Clone(m)      // want `golang.org/x/exp/maps\.Clone\(\) can be replaced by maps\.Clone\(\)`
 	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
 }

--- a/testdata/src/expalias/alias.go
+++ b/testdata/src/expalias/alias.go
@@ -1,0 +1,11 @@
+package expalias
+
+import (
+	aliased "golang.org/x/exp/maps"
+	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+)
+
+func _(m map[string]string, a, b []string) {
+	aliased.Clone(m)
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+}

--- a/testdata/src/expalias/alias.go.golden
+++ b/testdata/src/expalias/alias.go.golden
@@ -1,12 +1,13 @@
 package expalias
 
 import (
+	"golang.org/x/exp/maps"
 	aliased "golang.org/x/exp/maps"
-	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(m map[string]string, a, b []string) {
 	aliased.Clone(m)
+	maps.Clone(m)      // want `golang.org/x/exp/maps\.Clone\(\) can be replaced by maps\.Clone\(\)`
 	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
 }
-

--- a/testdata/src/expalias/alias.go.golden
+++ b/testdata/src/expalias/alias.go.golden
@@ -1,0 +1,12 @@
+package expalias
+
+import (
+	aliased "golang.org/x/exp/maps"
+	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+)
+
+func _(m map[string]string, a, b []string) {
+	aliased.Clone(m)
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+}
+

--- a/testdata/src/expalias/go.mod
+++ b/testdata/src/expalias/go.mod
@@ -1,0 +1,5 @@
+module expalias
+
+go 1.23.1
+
+require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/testdata/src/expalias/go.sum
+++ b/testdata/src/expalias/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/testdata/src/expboth/both.go
+++ b/testdata/src/expboth/both.go
@@ -1,8 +1,8 @@
 package expboth
 
 import (
-	"golang.org/x/exp/maps"   // want "Import statement can drop `golang.org/x/exp` prefix"
-	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"golang.org/x/exp/maps"   // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
+	"golang.org/x/exp/slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(m map[string]string, a, b []string) {

--- a/testdata/src/expboth/both.go
+++ b/testdata/src/expboth/both.go
@@ -1,0 +1,11 @@
+package expboth
+
+import (
+	"golang.org/x/exp/maps"   // want "Import statement can drop `golang.org/x/exp` prefix"
+	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+)
+
+func _(m map[string]string, a, b []string) {
+	maps.Clone(m)      // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+}

--- a/testdata/src/expboth/both.go.golden
+++ b/testdata/src/expboth/both.go.golden
@@ -1,0 +1,12 @@
+package expboth
+
+import (
+	"maps"   // want "Import statement can drop `golang.org/x/exp` prefix"
+	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+)
+
+func _(m map[string]string, a, b []string) {
+	maps.Clone(m)      // want `golang.org/x/exp/maps.Clone\(\) can be replaced by maps.Clone\(\)`
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+}
+

--- a/testdata/src/expboth/both.go.golden
+++ b/testdata/src/expboth/both.go.golden
@@ -1,8 +1,8 @@
 package expboth
 
 import (
-	"maps"   // want "Import statement can drop `golang.org/x/exp` prefix"
-	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"maps"   // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
+	"slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(m map[string]string, a, b []string) {

--- a/testdata/src/expboth/go.mod
+++ b/testdata/src/expboth/go.mod
@@ -1,0 +1,5 @@
+module expboth
+
+go 1.23.1
+
+require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/testdata/src/expboth/go.sum
+++ b/testdata/src/expboth/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/testdata/src/expmaps/maps.go
+++ b/testdata/src/expmaps/maps.go
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	`golang.org/x/exp/maps` // want "Import statement can drop `golang.org/x/exp` prefix"
+	`golang.org/x/exp/maps` // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
 )
 
 func _(m, a map[string]string) {

--- a/testdata/src/expmaps/maps.go.golden
+++ b/testdata/src/expmaps/maps.go.golden
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	"maps" // want "Import statement can drop `golang.org/x/exp` prefix"
+	`maps` // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
 )
 
 func _(m, a map[string]string) {

--- a/testdata/src/expmaps/maps.go.golden
+++ b/testdata/src/expmaps/maps.go.golden
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	`golang.org/x/exp/maps` // want "Import statement can drop `golang.org/x/exp` prefix"
+	"maps" // want "Import statement can drop `golang.org/x/exp` prefix"
 )
 
 func _(m, a map[string]string) {
@@ -25,3 +25,4 @@ func _(m, a map[string]string) {
 
 	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
 }
+

--- a/testdata/src/expmixed/go.mod
+++ b/testdata/src/expmixed/go.mod
@@ -1,0 +1,5 @@
+module expmixed
+
+go 1.23.1
+
+require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/testdata/src/expmixed/go.sum
+++ b/testdata/src/expmixed/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/testdata/src/expmixed/maps/maps.go
+++ b/testdata/src/expmixed/maps/maps.go
@@ -1,0 +1,3 @@
+package maps
+
+func Clone(_ map[string]string) {}

--- a/testdata/src/expmixed/mixed.go
+++ b/testdata/src/expmixed/mixed.go
@@ -3,7 +3,7 @@ package expmixed
 import (
 	"expmixed/maps"
 
-	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"golang.org/x/exp/slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(m map[string]string, a, b []string) {

--- a/testdata/src/expmixed/mixed.go
+++ b/testdata/src/expmixed/mixed.go
@@ -1,0 +1,12 @@
+package expmixed
+
+import (
+	"expmixed/maps"
+
+	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+)
+
+func _(m map[string]string, a, b []string) {
+	maps.Clone(m)
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+}

--- a/testdata/src/expmixed/mixed.go.golden
+++ b/testdata/src/expmixed/mixed.go.golden
@@ -3,7 +3,7 @@ package expmixed
 import (
 	"expmixed/maps"
 
-	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(m map[string]string, a, b []string) {

--- a/testdata/src/expmixed/mixed.go.golden
+++ b/testdata/src/expmixed/mixed.go.golden
@@ -1,0 +1,13 @@
+package expmixed
+
+import (
+	"expmixed/maps"
+
+	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+)
+
+func _(m map[string]string, a, b []string) {
+	maps.Clone(m)
+	slices.Equal(a, b) // want `golang.org/x/exp/slices\.Equal\(\) can be replaced by slices\.Equal\(\)`
+}
+

--- a/testdata/src/expnone/go.mod
+++ b/testdata/src/expnone/go.mod
@@ -1,0 +1,3 @@
+module expnone
+
+go 1.23.1

--- a/testdata/src/expnone/maps/maps.go
+++ b/testdata/src/expnone/maps/maps.go
@@ -1,0 +1,3 @@
+package maps
+
+func Clone(_ map[string]string) {}

--- a/testdata/src/expnone/none.go
+++ b/testdata/src/expnone/none.go
@@ -1,0 +1,11 @@
+package none
+
+import (
+	"expnone/maps"
+	"expnone/slices"
+)
+
+func _(m map[string]string, a, b []string) {
+	maps.Clone(m)
+	slices.Equal(a, b)
+}

--- a/testdata/src/expnone/none.go.golden
+++ b/testdata/src/expnone/none.go.golden
@@ -1,0 +1,11 @@
+package none
+
+import (
+	"expnone/maps"
+	"expnone/slices"
+)
+
+func _(m map[string]string, a, b []string) {
+	maps.Clone(m)
+	slices.Equal(a, b)
+}

--- a/testdata/src/expnone/slices/slices.go
+++ b/testdata/src/expnone/slices/slices.go
@@ -1,0 +1,3 @@
+package slices
+
+func Equal(_, _ []string) {}

--- a/testdata/src/expslices/slices.go
+++ b/testdata/src/expslices/slices.go
@@ -1,7 +1,7 @@
 package expslices
 
 import (
-	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"golang.org/x/exp/slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(a, b []string) {

--- a/testdata/src/expslices/slices.go.golden
+++ b/testdata/src/expslices/slices.go.golden
@@ -1,7 +1,7 @@
 package expslices
 
 import (
-	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"slices" // want "Import statement 'golang.org/x/exp/slices' can be replaced by 'slices'"
 )
 
 func _(a, b []string) {

--- a/testdata/src/expslices/slices.go.golden
+++ b/testdata/src/expslices/slices.go.golden
@@ -1,7 +1,7 @@
 package expslices
 
 import (
-	"golang.org/x/exp/slices" // want "Import statement can drop `golang.org/x/exp` prefix"
+	"slices" // want "Import statement can drop `golang.org/x/exp` prefix"
 )
 
 func _(a, b []string) {
@@ -59,3 +59,4 @@ func _(a, b []string) {
 		return 0
 	})
 }
+


### PR DESCRIPTION
- feat: Add fixer
  The fixer only works if all functions called from the `exp` imported
package can be replaced. If so, we add a diagnostic to the import
statement as well and replaces that one.
- fix: Ignore imports with alias
  Since aliased imports are not diagnosed (only calls with selector
`maps` and `slices` are checked) we can't safely know if we call any
method in the `exp` package that can't be replaced.

  With this change we check both if we ever returned `false` from the
check but even if we didn't (no checks were made) we avoid replacing the
import if it's aliased.

---

I thought it would be fairly easy to add a fixer for this, at least if we can confirm that we never called a method on the `maps` or `slices` package that we couldn't replace.

This PR is mostly test to try to ensure I cover all cases and false positives to not replace an import for aliased (not checked) or packages with the same name. If I'm missing something feel free to add some test cases for this.

The downside with this approach is that if we found duplicates, i.e. if we call some methods on `maps` that can be replaced and some that can't, we don't update the import. The rationale for this is that it would be too complex to keep track of potential aliasing and not only update/add the import but also update the calls where possible.