### PR TITLE
feat: suggested fix for 'maps.Clear'

### DIFF
--- a/exptostd.go
+++ b/exptostd.go
@@ -23,8 +23,9 @@ const (
 )
 
 type stdReplacement struct {
-	MinGo int
-	Text  string
+	MinGo      int
+	Text       string
+	KeepImport bool
 }
 
 type analyzer struct {
@@ -52,7 +53,7 @@ func NewAnalyzer() *analysis.Analyzer {
 			"Clone":      {MinGo: go121, Text: "maps.Clone()"},
 			"Copy":       {MinGo: go121, Text: "maps.Copy()"},
 			"DeleteFunc": {MinGo: go121, Text: "maps.DeleteFunc()"},
-			"Clear":      {MinGo: go121, Text: "clear()"},
+			"Clear":      {MinGo: go121, Text: "clear()", KeepImport: true},
 		},
 		slicesPkgReplacements: map[string]stdReplacement{
 			"Equal":        {MinGo: go121, Text: "slices.Equal()"},
@@ -180,7 +181,7 @@ func (a *analyzer) detectPackageUsage(pass *analysis.Pass,
 
 	if pkg.Imported().Path() == importPath {
 		pass.Reportf(callExpr.Pos(), "%s.%s() can be replaced by %s", importPath, selExpr.Sel.Name, rp.Text)
-		return true
+		return !rp.KeepImport
 	}
 
 	return false

--- a/exptostd.go
+++ b/exptostd.go
@@ -118,7 +118,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 
 	insp.Preorder(nodeFilter, func(n ast.Node) {
 		if importSpec, ok := n.(*ast.ImportSpec); ok {
-			cleanedPath := trimQuotes(importSpec)
+			cleanedPath := trimImportPath(importSpec)
 			imports[cleanedPath] = importSpec
 
 			return
@@ -220,7 +220,7 @@ func (a *analyzer) suggestReplaceImport(pass *analysis.Pass, imports map[string]
 		return
 	}
 
-	src := trimQuotes(imp)
+	src := trimImportPath(imp)
 
 	index := strings.LastIndex(src, "/")
 
@@ -285,6 +285,6 @@ func getGoVersion(pass *analysis.Pass) int {
 	return v
 }
 
-func trimQuotes(spec *ast.ImportSpec) string {
+func trimImportPath(spec *ast.ImportSpec) string {
 	return spec.Path.Value[1 : len(spec.Path.Value)-1]
 }

--- a/testdata/src/expmaps/maps.go
+++ b/testdata/src/expmaps/maps.go
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	`golang.org/x/exp/maps`
+	`golang.org/x/exp/maps` // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
 )
 
 func _(m, a map[string]string) {

--- a/testdata/src/expmaps/maps.go
+++ b/testdata/src/expmaps/maps.go
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	`golang.org/x/exp/maps` // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
+	`golang.org/x/exp/maps`
 )
 
 func _(m, a map[string]string) {

--- a/testdata/src/expmaps/maps.go.golden
+++ b/testdata/src/expmaps/maps.go.golden
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	`maps` // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
+	`maps`
 )
 
 func _(m, a map[string]string) {

--- a/testdata/src/expmaps/maps.go.golden
+++ b/testdata/src/expmaps/maps.go.golden
@@ -1,7 +1,7 @@
 package expmaps
 
 import (
-	`maps`
+	`maps` // want "Import statement 'golang.org/x/exp/maps' can be replaced by 'maps'"
 )
 
 func _(m, a map[string]string) {
@@ -23,6 +23,6 @@ func _(m, a map[string]string) {
 		return true
 	})
 
-	maps.Clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
+	clear(m) // want `golang.org/x/exp/maps.Clear\(\) can be replaced by clear\(\)`
 }
 


### PR DESCRIPTION
Adds a suggested fix for `maps.Clear`.

My first idea was to keep the import but a suggested fix was better.
I keep the first commit just for history (it will be dropped during the merge).