### PR TITLE
feat: detect usage of golang.org/x/exp/constraints.Ordered

### DIFF
--- a/exptostd.go
+++ b/exptostd.go
@@ -300,7 +300,7 @@ func (a *analyzer) detectConstraintsUsage(pass *analysis.Pass, expr ast.Expr) {
 		return
 	}
 
-	if rp.MinGo > a.goVersion {
+	if !a.skipGoVersionDetection && rp.MinGo > a.goVersion {
 		a.shouldKeepExpConstraints = true
 		return
 	}

--- a/exptostd.go
+++ b/exptostd.go
@@ -163,7 +163,6 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 
 			case "slices":
 				diagnostic, usage := a.detectPackageUsage(pass, a.slicesPkgReplacements, selExpr, ident, node, "golang.org/x/exp/slices")
-
 				if usage {
 					resultExpSlices.Diagnostics = append(resultExpSlices.Diagnostics, diagnostic)
 				}

--- a/exptostd.go
+++ b/exptostd.go
@@ -330,7 +330,7 @@ func (a *analyzer) detectConstraintsUsage(pass *analysis.Pass, selExpr *ast.Sele
 	a.constraintsDiagnostics = append(a.constraintsDiagnostics, diagnostic)
 }
 
-func (a *analyzer) suggestReplaceImport(pass *analysis.Pass, imports map[string]*ast.ImportSpec, shouldKeep bool, importPath string, stdPackage string) {
+func (a *analyzer) suggestReplaceImport(pass *analysis.Pass, imports map[string]*ast.ImportSpec, shouldKeep bool, importPath, stdPackage string) {
 	imp, ok := imports[importPath]
 	if !ok || shouldKeep {
 		return

--- a/exptostd.go
+++ b/exptostd.go
@@ -174,18 +174,24 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		case *ast.FuncDecl:
 			if node.Type.TypeParams != nil {
 				for _, field := range node.Type.TypeParams.List {
-					if selExpr, ok := field.Type.(*ast.SelectorExpr); ok {
-						a.detectConstraintsUsage(pass, selExpr)
+					selExpr, ok := field.Type.(*ast.SelectorExpr)
+					if !ok {
+						continue
 					}
+
+					a.detectConstraintsUsage(pass, selExpr)
 				}
 			}
 
 		case *ast.TypeSpec:
 			if node.TypeParams != nil {
 				for _, fieldType := range node.TypeParams.List {
-					if selExpr, ok := fieldType.Type.(*ast.SelectorExpr); ok {
-						a.detectConstraintsUsage(pass, selExpr)
+					selExpr, ok := fieldType.Type.(*ast.SelectorExpr)
+					if !ok {
+						continue
 					}
+
+					a.detectConstraintsUsage(pass, selExpr)
 				}
 			}
 

--- a/exptostd.go
+++ b/exptostd.go
@@ -393,7 +393,7 @@ func (a *analyzer) detectConstraintsUsage(pass *analysis.Pass, selExpr *ast.Sele
 
 	diagnostic := analysis.Diagnostic{
 		Pos:     selExpr.Pos(),
-		Message: "golang.org/x/exp/constraints.Ordered can be replaced by cmp.Ordered",
+		Message: fmt.Sprintf("golang.org/x/exp/constraints.%s can be replaced by %s", selExpr.Sel.Name, rp.Text),
 	}
 
 	if rp.Suggested != nil {

--- a/exptostd_test.go
+++ b/exptostd_test.go
@@ -22,6 +22,8 @@ func TestAnalyzer(t *testing.T) {
 		{dir: "expnone"},
 		{dir: "expmixed"},
 		{dir: "expalias"},
+		{dir: "expconstraints"},
+		{dir: "expconstraintskeep"},
 	}
 
 	for _, test := range testCases {

--- a/testdata/src/expconstraints/constraints.go
+++ b/testdata/src/expconstraints/constraints.go
@@ -1,0 +1,29 @@
+package expconstraints
+
+import (
+	"time"
+
+	"golang.org/x/exp/constraints" // want "Import statement 'golang.org/x/exp/constraints' can be replaced by 'cmp'"
+)
+
+type _[T constraints.Ordered] []T // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+
+type _ interface {
+	constraints.Ordered | time.Time // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+}
+
+type _ interface {
+	constraints.Ordered // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+	comparable
+}
+
+type _[K constraints.Ordered, V any] struct { // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+}
+
+func _[T constraints.Ordered](_ []T) bool { // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+	return true
+}
+
+func _[S []E, E constraints.Ordered](s S) E { // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+	return s[len(s)-1]
+}

--- a/testdata/src/expconstraints/constraints.go.golden
+++ b/testdata/src/expconstraints/constraints.go.golden
@@ -1,0 +1,29 @@
+package expconstraints
+
+import (
+	"time"
+
+	"cmp" // want "Import statement 'golang.org/x/exp/constraints' can be replaced by 'cmp'"
+)
+
+type _[T cmp.Ordered] []T // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+
+type _ interface {
+	cmp.Ordered | time.Time // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+}
+
+type _ interface {
+	cmp.Ordered // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+	comparable
+}
+
+type _[K cmp.Ordered, V any] struct { // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+}
+
+func _[T cmp.Ordered](_ []T) bool { // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+	return true
+}
+
+func _[S []E, E cmp.Ordered](s S) E { // want `golang.org/x/exp/constraints\.Ordered can be replaced by cmp\.Ordered`
+	return s[len(s)-1]
+}

--- a/testdata/src/expconstraints/go.mod
+++ b/testdata/src/expconstraints/go.mod
@@ -1,0 +1,5 @@
+module expslices
+
+go 1.23.0
+
+require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/testdata/src/expconstraints/go.sum
+++ b/testdata/src/expconstraints/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=

--- a/testdata/src/expconstraintskeep/constraints.go
+++ b/testdata/src/expconstraintskeep/constraints.go
@@ -5,5 +5,5 @@ import (
 )
 
 type _ interface {
-	constraints.Ordered | constraints.Float
+	constraints.Ordered | constraints.Float // want "golang.org/x/exp/constraints.Ordered can be replaced by cmp.Ordered"
 }

--- a/testdata/src/expconstraintskeep/constraints.go
+++ b/testdata/src/expconstraintskeep/constraints.go
@@ -1,0 +1,9 @@
+package expconstraintskeep
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+type _ interface {
+	constraints.Ordered | constraints.Float
+}

--- a/testdata/src/expconstraintskeep/constraints.go.golden
+++ b/testdata/src/expconstraintskeep/constraints.go.golden
@@ -5,5 +5,5 @@ import (
 )
 
 type _ interface {
-	constraints.Ordered | constraints.Float
+	cmp.Ordered | constraints.Float // want "golang.org/x/exp/constraints.Ordered can be replaced by cmp.Ordered"
 }

--- a/testdata/src/expconstraintskeep/constraints.go.golden
+++ b/testdata/src/expconstraintskeep/constraints.go.golden
@@ -1,0 +1,9 @@
+package expconstraintskeep
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+type _ interface {
+	constraints.Ordered | constraints.Float
+}

--- a/testdata/src/expconstraintskeep/go.mod
+++ b/testdata/src/expconstraintskeep/go.mod
@@ -1,0 +1,5 @@
+module expslices
+
+go 1.23.0
+
+require golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/testdata/src/expconstraintskeep/go.sum
+++ b/testdata/src/expconstraintskeep/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=


### PR DESCRIPTION
### What does this PR do?

detect usage of [golang.org/x/exp/constraints#Ordered](https://pkg.go.dev/golang.org/x/exp/constraints#Ordered)

### Motivation

[constraints.Ordered](https://pkg.go.dev/golang.org/x/exp/constraints#Ordered) was added in March 2023 to [golang.org/x/exp/constraints](https://pkg.go.dev/golang.org/x/exp/constraints)

[cmp.Ordered](https://pkg.go.dev/cmp#Ordered) was added to Go 1.21 to provide this type to standard library

It can be suggested for replacement by the linter if no other types are used

Fixes #4

### Additional Notes

Minor refactorings were made to prepare the changes

- refactor suggestReplaceImport
- refactor to use type assertion switch
